### PR TITLE
feat: Get and set sample rate via SCStreamConfiguration

### DIFF
--- a/src/stream/configuration/audio.rs
+++ b/src/stream/configuration/audio.rs
@@ -45,6 +45,19 @@ impl SCStreamConfiguration {
     pub fn get_channel_count(&self) -> u8 {
         get_property(self, sel!(channelCount))
     }
+
+    /// Sets the sample rate of this [`SCStreamConfiguration`].
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if sample rate is not properly set.
+    pub fn set_sample_rate(mut self, sample_rate: u32) -> Result<Self, CFError> {
+        set_property(&mut self, sel!(setSampleRate:), sample_rate)?;
+        Ok(self)
+    }
+    pub fn get_sample_rate(&self) -> u32 {
+        get_property(self, sel!(sampleRate))
+    }
 }
 
 


### PR DESCRIPTION
Problem: I'm not able to get/set sample_rate` in StreamConfiguration as a consumer of this library.

Solution: Wire up the getter & setter calls to the actual operations to set the aforementioned attributes via SCStreamConfiguration interface.

Testing: Tested on my Macbook. I'm able to update the sample rate attribute and see the changes reflected in the sample rate of the audio samples that I'm receiving in `did_output_sample_buffer` callback.

Reviewer guidance: I am only adding the missing attribute that I need. I'm aware that there are still remaining attributes that are not set via objc interface but decided to only focus on `sample_rate` attributes in this PR since I have high confidence that they would work from my local testing.